### PR TITLE
fix(ArenaActivePlayerCounter): Safari で表示出来ていなかったのを修正

### DIFF
--- a/src/components/ArenaActivePlayerCounter.ts
+++ b/src/components/ArenaActivePlayerCounter.ts
@@ -1,16 +1,18 @@
-export class ArenaActivePlayerCounter extends HTMLDivElement {
+export class ArenaActivePlayerCounter extends HTMLElement {
   #single: number | null = null;
   #double: number | null = null;
 
   textElement = document.createElement("p");
 
-  constructor() {
-    super();
-
-    this.classList.add("frame");
+  connectedCallback() {
+    const frameElement = document.createElement("div");
+    frameElement.setAttribute("class", "frame");
 
     this.textElement.innerText = this.text;
-    this.append(this.textElement);
+
+    frameElement.append(this.textElement);
+
+    this.append(frameElement);
   }
 
   set single(val: number) {

--- a/src/createArenaPlayerCounter.ts
+++ b/src/createArenaPlayerCounter.ts
@@ -12,13 +12,14 @@ export function createArenaPlayerCounter() {
     DOUBLE = "1",
   }
 
-  customElements.define("arena-active-player-count", ArenaActivePlayerCounter, {
-    extends: "div",
-  });
+  customElements.define(
+    "arena-active-player-counter",
+    ArenaActivePlayerCounter,
+  );
 
-  const counterElement = document.createElement("div", {
-    is: "arena-active-player-count",
-  }) as ArenaActivePlayerCounter;
+  const counterElement = document.createElement(
+    "arena-active-player-counter",
+  ) as ArenaActivePlayerCounter;
   playMenu.append(counterElement);
 
   $(document).on(


### PR DESCRIPTION
Safari では組み込み要素を継承して CustomElement を定義することがサポートされていないため，
自律した要素として定義する

[カスタム要素の使用#高水準のビュー - mdn](https://developer.mozilla.org/ja/docs/Web/API/Web_Components/Using_custom_elements#高水準のビュー)